### PR TITLE
Biome fixes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,27 +1,13 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
   "formatter": {
-    "enabled": true,
-    "formatWithErrors": false,
     "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 100,
-    "attributePosition": "auto"
+    "lineWidth": 100
   },
-  "organizeImports": { "enabled": true },
-  "linter": { "enabled": true, "rules": { "recommended": true } },
   "javascript": {
     "formatter": {
-      "jsxQuoteStyle": "double",
-      "quoteProperties": "asNeeded",
-      "trailingCommas": "all",
       "semicolons": "asNeeded",
-      "arrowParentheses": "always",
       "bracketSpacing": false,
-      "bracketSameLine": false,
-      "quoteStyle": "single",
-      "attributePosition": "auto"
+      "quoteStyle": "single"
     }
   },
   "vcs": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,7 +140,7 @@ const App = () => {
               return (
                 <Validation
                   key={`val${index}`}
-                  schema={evaluatedSchema}
+                  schema={evaluatedSchema as zod.ZodSchema}
                   value={value}
                   index={index}
                   onAdd={() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ const App = () => {
     }
 
     updateVersion(monaco, version)
-  }, [version, monaco])
+  }, [version, monaco, isLoading])
 
   return (
     <Box className={classes.layout}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ const App = () => {
 
   const {data: evaluatedSchema, error: schemaError} = zod.validateSchema(schema)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isLoading is not a dependency
   useEffect(() => {
     if (isLoading || !monaco) return
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ const App = () => {
             {values.map((value, index) => {
               return (
                 <Validation
+                  // biome-ignore lint/suspicious/noArrayIndexKey: items order does not change
                   key={`val${index}`}
                   schema={evaluatedSchema as zod.ZodSchema}
                   value={value}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,9 @@ const App = () => {
   const monaco = useMonaco()
   const computedColorScheme = useComputedColorScheme('light')
 
-  const {data: evaluatedSchema, error: schemaError} = zod.validateSchema(schema)
+  const schemaValidation = zod.validateSchema(schema)
+  const evaluatedSchema = schemaValidation.success ? schemaValidation.data : undefined
+  const schemaError = !schemaValidation.success ? schemaValidation.error : undefined
 
   useEffect(() => {
     if (!monaco) return
@@ -141,7 +143,7 @@ const App = () => {
                 <Validation
                   // biome-ignore lint/suspicious/noArrayIndexKey: items order does not change
                   key={`val${index}`}
-                  schema={evaluatedSchema as zod.ZodSchema}
+                  schema={evaluatedSchema}
                   value={value}
                   index={index}
                   onAdd={() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ const App = () => {
     }
 
     updateVersion(monaco, version)
-  }, [version, monaco, isLoading])
+  }, [version, monaco])
 
   return (
     <Box className={classes.layout}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,9 +48,8 @@ const App = () => {
 
   const {data: evaluatedSchema, error: schemaError} = zod.validateSchema(schema)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: isLoading is not a dependency
   useEffect(() => {
-    if (isLoading || !monaco) return
+    if (!monaco) return
 
     async function updateVersion(monaco: Monaco, ver: string) {
       setIsLoading(true)

--- a/src/features/ValueEditor/ValueEditor.tsx
+++ b/src/features/ValueEditor/ValueEditor.tsx
@@ -21,7 +21,7 @@ import {CopyButton} from '../CopyButton'
 import classes from './ValueEditor.module.css'
 
 interface Props {
-  schema: any
+  schema: zod.ZodSchema
   value: string
   index: number
   onAdd: () => void

--- a/src/features/ValueEditor/ValueEditor.tsx
+++ b/src/features/ValueEditor/ValueEditor.tsx
@@ -21,7 +21,7 @@ import {CopyButton} from '../CopyButton'
 import classes from './ValueEditor.module.css'
 
 interface Props {
-  schema: zod.ZodSchema
+  schema?: zod.ZodSchema
   value: string
   index: number
   onAdd: () => void
@@ -55,7 +55,9 @@ export const Validation = ({schema, value, index, onChange, onAdd, onRemove, onC
   const [opened, {close, open}] = useDisclosure(false)
   const [openedResult, {toggle: toggleResult}] = useDisclosure(false)
 
-  const validation = zod.validateValue(schema, value)
+  const validation = schema
+    ? zod.validateValue(schema, value)
+    : {success: false as const, error: 'Invalid schema'}
   const parsedData = validation.success && JSON.stringify(validation.data)
 
   const errors = !validation.success && validation.error

--- a/src/ui/Header/Header.tsx
+++ b/src/ui/Header/Header.tsx
@@ -11,6 +11,7 @@ export const ZodLogo = () => (
     style={{fillRule: 'evenodd', clipRule: 'evenodd', strokeMiterlimit: 5}}
     className={classes.header__logo}
   >
+    <title>Zod Logo</title>
     <use
       xlinkHref="#_Image1"
       x="112.458"

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -8,11 +8,25 @@ export type ZodSchema = {
   }
 }
 
-type ZodValidation = {
-  success: boolean
-  data?: unknown
-  error?: string
-}
+type SchemaValidation =
+  | {
+      success: true
+      data: ZodSchema
+    }
+  | {
+      success: false
+      error: string
+    }
+
+type ValueValidation =
+  | {
+      success: true
+      data: unknown
+    }
+  | {
+      success: false
+      error: string
+    }
 
 type ZodIssue = {
   code: string
@@ -77,11 +91,11 @@ export async function setVersion(ver: string) {
   _z = await import(/* @vite-ignore */ `https://cdn.jsdelivr.net/npm/zod@${ver}/+esm`)
 }
 
-export function validateSchema(schema: string): ZodValidation {
+export function validateSchema(schema: string): SchemaValidation {
   try {
     if (schema.length < 3) throw new Error('Schema is too short')
 
-    const data = new Function('z', `return ${schema}`)(_z)
+    const data = new Function('z', `return ${schema}`)(_z) as ZodSchema
 
     return {
       success: true,
@@ -96,7 +110,7 @@ export function validateSchema(schema: string): ZodValidation {
   }
 }
 
-export function validateValue(schema: ZodSchema, value: string): ZodValidation {
+export function validateValue(schema: ZodSchema, value: string): ValueValidation {
   const evaluatedValue = evalExp(value)
   if (!evaluatedValue.success) return evaluatedValue
 
@@ -117,7 +131,7 @@ export function validateValue(schema: ZodSchema, value: string): ZodValidation {
   }
 }
 
-function evalExp(expression: string): ZodValidation {
+function evalExp(expression: string): ValueValidation {
   try {
     const evaluatedExpression = new Function(`return ${expression}`)()
     return {

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -87,7 +87,7 @@ export function validateSchema(schema: string): ZodValidation {
       success: true,
       data,
     }
-  } catch (e: unknown) {
+  } catch (e) {
     const error = e instanceof Error ? e.message : 'Unknown error'
     return {
       success: false,
@@ -124,7 +124,7 @@ function evalExp(expression: string): ZodValidation {
       success: true,
       data: evaluatedExpression,
     }
-  } catch (e: unknown) {
+  } catch (e) {
     const error = e instanceof Error ? e.message : 'Unknown error'
     return {
       success: false,

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,56 +1,3 @@
-export type ZodSchema = {
-  safeParse: (data: unknown) => {
-    success: boolean
-    data: unknown
-    error: {
-      issues: ZodIssue[]
-    }
-  }
-}
-
-type SchemaValidation =
-  | {
-      success: true
-      data: ZodSchema
-    }
-  | {
-      success: false
-      error: string
-    }
-
-type ValueValidation =
-  | {
-      success: true
-      data: unknown
-    }
-  | {
-      success: false
-      error: string
-    }
-
-type ZodIssue = {
-  code: string
-  path: (string | number)[]
-  message: string
-}
-
-type JsDelivrMetadata = {
-  type: string
-  name: string
-  tags: Record<string, string>
-  versions: {
-    version: string
-    links: {
-      self: string
-      entrypoints: string
-      stats: string
-    }
-  }[]
-  links: {
-    stats: string
-  }
-}
-
 let _metadata: JsDelivrMetadata
 let _z: unknown
 
@@ -156,4 +103,57 @@ function generateErrorMessage(issues: ZodIssue[]) {
   }
 
   return messages.join('\n')
+}
+
+export type ZodSchema = {
+  safeParse: (data: unknown) => {
+    success: boolean
+    data: unknown
+    error: {
+      issues: ZodIssue[]
+    }
+  }
+}
+
+type ZodIssue = {
+  code: string
+  path: (string | number)[]
+  message: string
+}
+
+type SchemaValidation =
+  | {
+      success: true
+      data: ZodSchema
+    }
+  | {
+      success: false
+      error: string
+    }
+
+type ValueValidation =
+  | {
+      success: true
+      data: unknown
+    }
+  | {
+      success: false
+      error: string
+    }
+
+type JsDelivrMetadata = {
+  type: string
+  name: string
+  tags: Record<string, string>
+  versions: {
+    version: string
+    links: {
+      self: string
+      entrypoints: string
+      stats: string
+    }
+  }[]
+  links: {
+    stats: string
+  }
 }


### PR DESCRIPTION
```
src/App.tsx:142:30 lint/suspicious/noArrayIndexKey ━━━━━━━━━━━━━━━━━━━━━

  ✖ Avoid using the index of an array as key property in an element.
  
    140 │               return (
    141 │                 <Validation
  > 142 │                   key={`val${index}`}
        │                              ^^^^^
    143 │                   schema={evaluatedSchema as zod.ZodSchema}
    144 │                   value={value}
  
  ℹ This is the source of the key value.
  
    137 │         <div className={classes.rightPanel}>
    138 │           <div className={classes.valuesStack}>
  > 139 │             {values.map((value, index) => {
        │                                 ^^^^^
    140 │               return (
    141 │                 <Validation
  
  ℹ The order of the items may change, and this also affects performances and component state.
  
  ℹ Check the React documentation. 
```

What do you think about this?