### PR TITLE
Fix monaco editor content in test cases

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,12 +17,20 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: {...devices['Desktop Chrome']},
+      use: {
+        ...devices['Desktop Chrome'],
+
+        // Enable clipboard permissions for Chromium to support copy-paste in tests
+        permissions: ['clipboard-read', 'clipboard-write'],
+      },
     },
 
     {
       name: 'firefox',
-      use: {...devices['Desktop Firefox']},
+      use: {
+        ...devices['Desktop Firefox'],
+        // Firefox does not support clipboard permissions but copy-paste works by default
+      },
     },
   ],
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -92,8 +92,16 @@ const writeInMonaco = async ({
   await locator.click()
   if (replacePreviousContent) {
     await page.keyboard.press('ControlOrMeta+KeyA')
+    await page.waitForTimeout(100) // Wait to ensure content is selected
   }
-  await page.keyboard.type(text)
+  /**
+   * Using clipboard to paste the content to avoid those issues:
+   * - keyboard.type() cannot be used for auto-closing of brackets/quotes in monaco editor
+   * - keyboard.insertText() sometimes does not work properly in firefox
+   */
+  await page.evaluate((t) => navigator.clipboard.writeText(t), text)
+  await page.keyboard.press('ControlOrMeta+KeyV')
+  await page.waitForTimeout(100) // Wait to ensure content is pasted
 }
 
 /**


### PR DESCRIPTION
```
    - Fix monaco editor content in test cases
    Most of the tests currently checks for invalid values, so they were
    accidentally passing even if the content was not properly written.
    Moreover this change is necessary to write content with brackets and/or
    quotes.

    - Set playwright workers to 1 for all environments
    Execution time is not a problem atm. With 1 worker its easier to debug
    stuff.