### PR TITLE
Switch default schema when toggling between zod and zod mini

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,14 @@ const App = () => {
                   onChange={async (ver) => {
                     setVersion(ver.version)
                     setIsZodMini(ver.isZodMini)
+
+                    if (!isZodMini && ver.isZodMini && schema === DEFAULT_APP_DATA.schema) {
+                      setSchema(DEFAULT_APP_DATA.zodMiniSchema)
+                    }
+
+                    if (isZodMini && !ver.isZodMini && schema === DEFAULT_APP_DATA.zodMiniSchema) {
+                      setSchema(DEFAULT_APP_DATA.schema)
+                    }
                   }}
                   disabled={isLoading}
                 />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,12 +27,24 @@ const schema = z.object({
 
 return schema`
 
+// A version of the default schema that uses zod mini syntax
+const zodMiniSchema = `// Configure the locale for error messages (optional)
+// z.config(z.locales.it())
+
+const schema = z.object({
+  name: z.string(),
+  birth_year: z.optional(z.number())
+})
+
+return schema`
+
 const values = ['{name: "John"}']
 
 const version = (await zod.getVersions('latest'))[0].version
 
 export const DEFAULT_APP_DATA = {
   schema,
+  zodMiniSchema,
   values,
   version,
   isZodMini: false,

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -45,6 +45,20 @@ test('zod version switch', async ({page}) => {
   ).toBeVisible()
 })
 
+test('switching to zod mini swaps untouched default schema', async ({page, codeEditors}) => {
+  const latestZodVersion = (await zod.getVersions('latest'))[0]
+
+  const initialSchema = await codeEditors.getSchemaEditorContent()
+  expect(initialSchema).toContain('birth_year:z.number().optional()')
+
+  await page.getByRole('button', {name: `zod v${latestZodVersion.version}`}).click()
+  await page.getByText('zod/mini').click()
+  await page.getByRole('option', {name: latestZodVersion.version}).click()
+
+  const miniSchema = await codeEditors.getSchemaEditorContent()
+  expect(miniSchema).toContain('birth_year:z.optional(z.number())')
+})
+
 test('has default schema', async ({codeEditors}) => {
   const editorValue = await codeEditors.getSchemaEditorContent()
 


### PR DESCRIPTION
Before, if the user switched to zod/mini, the default schema became invalid and an error showed up because the default schema uses functions that are not in zod/mini. This is not the best UX, since the default schema should be valid. This PR fixes that by switching to another default schema that uses zod/mini syntax when the user switches to zod/mini without changing the schema, and switching it back if the user switches to the normal zod version.

This problem could also be fixed in a simpler way by using a default schema that does not use any feature missing in zod/mini. For example, remove `.optional()` and make the default schema like this:

```js
// Configure the locale for error messages (optional)
// z.config(z.locales.it())

const schema = z.object({
  name: z.string(),
  birth_year: z.number()
})

return schema
```

I chose the first solution to avoid changing the default schema. If you prefer updating the default schema instead, I can close this PR and open another one to do that.