### PR TITLE
Add a button to reset app data to defaults

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -60,3 +60,10 @@
     overflow-y: auto;
   }
 }
+
+.shareButton {
+  display: flex;
+  align-items: center;
+  font-size: var(--mantine-font-size-sm);
+  font-weight: 600;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,6 +103,7 @@ const App = () => {
       <Header>
         <Tooltip withArrow label="Create a link to share the current schema and values">
           <Button
+            className={classes.shareButton}
             variant="light"
             onClick={() => {
               const urlWithAppData = getURLwithAppData(appData)
@@ -113,10 +114,13 @@ const App = () => {
                 icon: <FiLink />,
               })
             }}
-            rightSection={<FiLink />}
             color="primary"
+            px={{base: 9, xs: 'md'}}
           >
-            Share
+            <Box mr="sm" visibleFrom="xs">
+              Share
+            </Box>
+            <FiLink />
           </Button>
         </Tooltip>
         <ColorSchemeToggle />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import {notifications} from '@mantine/notifications'
 import Editor, {type Monaco, useMonaco} from '@monaco-editor/react'
 import {useEffect, useMemo, useState} from 'react'
 import {FiAlertCircle, FiLink} from 'react-icons/fi'
-import {LuEraser} from 'react-icons/lu'
+import {LuEraser, LuRefreshCw} from 'react-icons/lu'
 import classes from './App.module.css'
 import {DEFAULT_APP_DATA, EDITOR_OPTIONS} from './constants'
 import {ColorSchemeToggle} from './features/ColorSchemeToggle'
@@ -120,6 +120,21 @@ const App = () => {
           </Button>
         </Tooltip>
         <ColorSchemeToggle />
+        <Tooltip withArrow label="Reset app data">
+          <ActionIcon
+            variant="light"
+            aria-label="Reset app data"
+            size="lg"
+            onClick={() => {
+              setSchema(DEFAULT_APP_DATA.schema)
+              setValues(DEFAULT_APP_DATA.values)
+              setVersion(DEFAULT_APP_DATA.version)
+              setIsZodMini(DEFAULT_APP_DATA.isZodMini)
+            }}
+          >
+            <LuRefreshCw />
+          </ActionIcon>
+        </Tooltip>
       </Header>
       <main style={{maxWidth: '100vw'}}>
         <ResizablePanelGroup

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,7 @@ const App = () => {
             }}
             color="primary"
             px={{base: 9, xs: 'md'}}
+            aria-label="Share"
           >
             <Box mr="sm" visibleFrom="xs">
               Share

--- a/src/features/VersionPicker/VersionPicker.tsx
+++ b/src/features/VersionPicker/VersionPicker.tsx
@@ -35,6 +35,10 @@ export function VersionPicker({
   const [isZodMini, setIsZodMini] = useState(value.isZodMini)
 
   useEffect(() => {
+    setIsZodMini(value.isZodMini)
+  }, [value.isZodMini])
+
+  useEffect(() => {
     setLoading(true)
 
     zod

--- a/src/ui/Header/Header.module.css
+++ b/src/ui/Header/Header.module.css
@@ -14,8 +14,15 @@
 
 .header__logo {
   width: 40px;
+  @media screen and (max-width: 480px) {
+    width: 30px;
+  }
 }
 
 .githubLink {
   font-size: 2rem;
+
+  @media screen and (max-width: 480px) {
+    font-size: 1.5rem;
+  }
 }

--- a/tests/app.e2e.ts
+++ b/tests/app.e2e.ts
@@ -69,6 +69,41 @@ test('has invalid marker when an invalid value is in the Value Editor', async ({
   await expect(page.locator('button').filter({hasText: /^Invalid$/})).toBeVisible()
 })
 
+test('reset app data button restores schema, value and zod version', async ({
+  page,
+  codeEditors,
+}) => {
+  const latestZodVersion = (await zod.getVersions('latest'))[0]
+  const anotherZodVersion = (await zod.getVersions())[3]
+
+  await codeEditors.writeSchema({
+    text: 'z.number()',
+  })
+
+  await codeEditors.writeValue({
+    text: '"invalid"',
+  })
+
+  await expect(page.locator('button').filter({hasText: /^Invalid$/})).toBeVisible()
+
+  await page.getByRole('button', {name: `zod v${latestZodVersion.version}`}).click()
+  await page.getByRole('option', {name: anotherZodVersion.version}).click()
+  await expect(page.getByRole('button', {name: `zod v${anotherZodVersion.version}`})).toBeVisible()
+
+  await page.getByLabel('Reset app data').click()
+
+  await expect(page.locator('button').filter({hasText: /^Valid$/})).toBeVisible()
+  await expect(page.getByRole('button', {name: `zod v${latestZodVersion.version}`})).toBeVisible()
+
+  const schemaValue = await codeEditors.getSchemaEditorContent()
+  expect(schemaValue).toEqual(
+    '123456789//Configurethelocaleforerrormessages(optional)//z.config(z.locales.it())constschema=z.object({name:z.string(),birth_year:z.number().optional()})returnschema',
+  )
+
+  const valueEditorContent = await codeEditors.getValueEditorsContent()
+  expect(valueEditorContent).toEqual('1{name:"John"}')
+})
+
 test('should display results by default on wide screen', async ({page, codeEditors}) => {
   await page.setViewportSize({width: 1920, height: 1080})
   await codeEditors.writeSchema({


### PR DESCRIPTION
Adds a reset button that resets the schema, values, and Zod version back to their default state. This helps a user to get a working schema after removing the schema, specially that the data persists through the localStorage after the user closes the page.

Since the header was full and cramped in small screens, I got space for it by removing the text "Share" from the share button and just keeping the icon in small screens, and making the GitHub icon and the Zod icon a little smaller on smaller screens.

Here is before:

<img width="570" height="622" alt="image" src="https://github.com/user-attachments/assets/8312d0ff-0697-4501-8197-a60633a4eb49" />

and after:

<img width="570" height="622" alt="image" src="https://github.com/user-attachments/assets/25a66eae-da94-45b8-acde-9603062d571b" />


and on extra small screen here is before:

<img width="460" height="622" alt="image" src="https://github.com/user-attachments/assets/7e8d4309-62e3-4e72-8945-974393f36ec5" />

and after:

<img width="460" height="622" alt="image" src="https://github.com/user-attachments/assets/7a7c92ae-d0cc-4a74-baf6-e9c5af586318" />


Note: the header already had some problems on really small screens, this PR does not fix all of the problems but fixes some of them and makes the header responsiveness overall better.